### PR TITLE
Attempt to fix one of several USDImaging Nested Instancing Update Bugs

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/instanceAdapter.cpp
@@ -407,6 +407,7 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
     // so now it's safe to re-enter this function to populate the
     // nested instances we discovered.
     TF_FOR_ALL(nestedInstanceIt, nestedInstances) {
+        instancerData.nestedInstances.push_back(nestedInstanceIt->GetPath());
         _Populate(*nestedInstanceIt, index, instancerContext,
                   instancerProxyPath);
     }
@@ -1541,6 +1542,14 @@ UsdImagingInstanceAdapter::_ResyncInstancer(SdfPath const& instancerPath,
             _masterToInstancerMap.erase(it);
             break;
         }
+    }
+
+    if (!TF_VERIFY(instIt != _instancerData.end())) {
+      return;
+    }
+    const SdfPathVector &nestedInstances = instIt->second.nestedInstances;
+    TF_FOR_ALL(nestedIt, nestedInstances) {
+      _ResyncInstancer(*nestedIt, index, false); //hoping the repopulate only needs to happen once
     }
 
     // Blow away the instancer and the associated local data.

--- a/pxr/usdImaging/lib/usdImaging/instanceAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/instanceAdapter.h
@@ -441,6 +441,10 @@ private:
         // instancer, the actual relationship is more like a directed graph.
         SdfPathSet childInstancers;
 
+        // Store nested instances to make removal easier
+        std::vector<SdfPath> nestedInstances;
+
+
         // Proto group containing the instance indexes for each prototype
         // rprim.
         _ProtoGroupPtr protoGroup;


### PR DESCRIPTION
### Description of Change(s)
This is an attempted  fix for https://groups.google.com/forum/#!topic/usd-interest/YPK05ebe8x4.
The most pared down examples of this are here:https://gist.github.com/murphyeoin/03637aaa39ced964e0d27cd207cc0b00


* Disappointlingly, this does not fix either of the repros from this [issue](https://github.com/PixarAnimationStudios/USD/issues/779)
* I only understand a small amount of the code, so this fix is designed to minimise side-effects
* we are testing it in production now (definitely needs some more work - currently getting Coding Error: in _ResyncInstancer at line 1213 of PLACEHOLDER/scratch/dev/AL_USD/usdImaging/pxr/usdImaging/lib/usdImaging/instanceAdapter.cpp – Failed verification: ' instIt != _instancerData.end() '
in some circumstances)

### Fixes Issue(s)
-

